### PR TITLE
Fix row count off by one

### DIFF
--- a/backend/common/nfdump.php
+++ b/backend/common/nfdump.php
@@ -111,6 +111,9 @@ class NfDump {
             return $output; // return output if it is a flows/packets/bytes dump
         }
         
+        // remove the 3 summary lines at the end of the csv output
+        $output = array_slice($output, 0, -3);
+
         // slice csv (only return the fields actually wanted)
         $fields_active = array();
         $parsed_header = false;

--- a/frontend/js/nfsen-ng.js
+++ b/frontend/js/nfsen-ng.js
@@ -841,7 +841,7 @@ $(document).ready(function() {
             });
 
             // generate table data
-            var temprows = data.slice(2, data.length - 4),
+            var temprows = data.slice(2),
                 rows = [];
 
             $.each(temprows, function (i, val) {


### PR DESCRIPTION
The csv output includes three summary rows at the end, e.g.
> Summary
flows,bytes,packets,avg_bps,avg_pps,avg_bpp
20,1018704,6576,46,0,154

nfsen-ng.js strips these off, but takes 4 rows instead of three, losing a row of actual data:

`var temprows = data.slice(2, data.length - 4),`

For example, aggregate by proto with a filter of *proto tcp* should produce a single row, but I see no results.

This can be fixed by replacing -4 with -3 above, but I thought it better to do this in the backend since the backend is responsible for producing the data and should understand the nfdump output. The frontend is then responsible only for display.