### PR TITLE
Support for custom NfDump

### DIFF
--- a/backend/api/api.php
+++ b/backend/api/api.php
@@ -2,7 +2,7 @@
 
 namespace nfsen_ng\api;
 
-use nfsen_ng\common\{Debug, Config, NfDump};
+use nfsen_ng\common\{Debug, Config};
 
 class API {
     private $method;
@@ -136,6 +136,12 @@ class API {
         exit();
     }
     
+    private function NewNfDump()
+    {
+        $nfdump_class = 'nfsen_ng\\common\\'.Config::$cfg['general']['nfdump'];
+        return new $nfdump_class();
+    }
+
     /**
      * Execute the nfdump command to get statistics
      *
@@ -162,7 +168,7 @@ class API {
     ) {
         $sources = implode(':', $sources);
         
-        $nfdump = new NfDump();
+        $nfdump = self::NewNfDump();
         $nfdump->setOption('-M', $sources); // multiple sources
         $nfdump->setOption('-R', array($datestart, $dateend)); // date range
         $nfdump->setOption('-n', $top);
@@ -211,7 +217,7 @@ class API {
             $aggregate_command = ($aggregate === 'bidirectional') ? '-B' : '-A' . $aggregate; // no space inbetween
         
         
-        $nfdump = new NfDump();
+        $nfdump = self::NewNfDump();
         $nfdump->setOption('-M', $sources); // multiple sources
         $nfdump->setOption('-R', array($datestart, $dateend)); // date range
         $nfdump->setOption('-c', $limit); // limit

--- a/backend/settings/settings.php.dist
+++ b/backend/settings/settings.php.dist
@@ -16,6 +16,7 @@ $nfsen_config = array(
             'source1', 'source2',
         ),
         'db' => 'RRD',
+        'nfdump' => 'NfDump',
     ),
     'frontend' => array(
         'reload_interval' => 60,


### PR DESCRIPTION
This diff adds support for custom NfDump implementation by specifying an nfdump class in settings (similarly to the way custom databases are supported). I use this to allow nfsen-ng to run in a php chroot without direct access to the nfcapd files. The original nfsen supports this.

My custom nfdump model (not included here), which is similar to the original nfsen, is to run a separate nfsend daemon and have nfsen-ng communicate via a fifo. This could also work using a socket which would allow nfsen-ng to run on a different host from that where the nfcapd files reside. 

You may consider this too obscure to support within the nfsen-ng code base, although the additional complexity is minimal. If you are concerned that existing nfsen-ng users will be required to add the nfdump entry in the general settings then I can alter NewNfDump() to default to the normal nfsen-ng NfDump implementation if there is no nfdump class specified in settings.