### PR TITLE
Remove auto output format

### DIFF
--- a/backend/common/nfdump.php
+++ b/backend/common/nfdump.php
@@ -6,7 +6,7 @@ class NfDump {
     private $cfg = array(
         'env' => array(),
         'option' => array(),
-        'format' => 'auto',
+        'format' => 'line',
         'filter' => array()
     );
     private $clean = array();
@@ -234,7 +234,6 @@ class NfDump {
         switch ($format) {
             // nfdump format: %ts %td %pr %sap %dap %pkt %byt %fl
             // csv output: ts,te,td,sa,da,sp,dp,pr,flg,fwd,stos,ipkt,ibyt,opkt,obyt,in,out,sas,das,smk,dmk,dtos,dir,nh,nhb,svln,dvln,ismc,odmc,idmc,osmc,mpls1,mpls2,mpls3,mpls4,mpls5,mpls6,mpls7,mpls8,mpls9,mpls10,cl,sl,al,ra,eng,exid,tr
-            case 'auto':
             case 'line':
                 return array('ts', 'td', 'pr', 'sa', 'sp', 'da', 'dp', 'ipkt', 'ibyt', 'fl');
                 // nfdump format: %ts %td %pr %sap %dap %flg %tos %pkt %byt %fl

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -302,7 +302,6 @@
                             <div class="form-group col-xs-6 col-sm-6">
                                 <label for="filterOutputSelection">Output type</label>
                                 <select id="filterOutputSelection" name="filterOutputSelection" class="form-control">
-                                    <option value="auto">Auto</option>
                                     <option value="line">Line</option>
                                     <option value="long">Long</option>
                                     <option value="extended">Extended</option>


### PR DESCRIPTION
Even though the original nfsen has an "auto" output format, I don't see the point in it because it is equivalent to "line". I find it confusing to have two options that have the same behaviour. nfdump defaults to "line" if no -o switch is provided, but the nfsen-ng UI can emulate that simply by making line the default option in the drop down.