### PR TITLE
Introduce Processor interface

### DIFF
--- a/backend/api/api.php
+++ b/backend/api/api.php
@@ -2,7 +2,7 @@
 
 namespace nfsen_ng\api;
 
-use nfsen_ng\common\{Debug, Config, NfDump};
+use nfsen_ng\common\{Debug, Config};
 
 class API {
     private $method;
@@ -137,7 +137,7 @@ class API {
     }
     
     /**
-     * Execute the nfdump command to get statistics
+     * Execute the processor to get statistics
      *
      * @param int    $datestart
      * @param int    $dateend
@@ -162,17 +162,17 @@ class API {
     ) {
         $sources = implode(':', $sources);
         
-        $nfdump = new NfDump();
-        $nfdump->setOption('-M', $sources); // multiple sources
-        $nfdump->setOption('-R', array($datestart, $dateend)); // date range
-        $nfdump->setOption('-n', $top);
-        $nfdump->setOption('-s', $for);
-        if (!empty($limit)) $nfdump->setOption('-l', $limit); // todo -L for traffic, -l for packets
-        if (isset($output['IPv6'])) $nfdump->setOption('-6', null);
-        $nfdump->setFilter($filter);
+        $processor = new Config::$processorClass();
+        $processor->setOption('-M', $sources); // multiple sources
+        $processor->setOption('-R', array($datestart, $dateend)); // date range
+        $processor->setOption('-n', $top);
+        $processor->setOption('-s', $for);
+        if (!empty($limit)) $processor->setOption('-l', $limit); // todo -L for traffic, -l for packets
+        if (isset($output['IPv6'])) $processor->setOption('-6', null);
+        $processor->setFilter($filter);
         
         try {
-            $return = $nfdump->execute();
+            $return = $processor->execute();
         } catch (\Exception $e) {
             $this->error(503, $e->getMessage());
         }
@@ -181,7 +181,7 @@ class API {
     }
     
     /**
-     * Execute the nfdump command to get flows
+     * Execute the processor to get flows
      *
      * @param int    $datestart
      * @param int    $dateend
@@ -211,19 +211,19 @@ class API {
             $aggregate_command = ($aggregate === 'bidirectional') ? '-B' : '-A' . $aggregate; // no space inbetween
         
         
-        $nfdump = new NfDump();
-        $nfdump->setOption('-M', $sources); // multiple sources
-        $nfdump->setOption('-R', array($datestart, $dateend)); // date range
-        $nfdump->setOption('-c', $limit); // limit
-        $nfdump->setOption('-o', $output['format']);
+        $processor = new Config::$processorClass();
+        $processor->setOption('-M', $sources); // multiple sources
+        $processor->setOption('-R', array($datestart, $dateend)); // date range
+        $processor->setOption('-c', $limit); // limit
+        $processor->setOption('-o', $output['format']);
         
-        if (!empty($sort)) $nfdump->setOption('-O', 'tstart');
-        if (array_key_exists('IPv6', $output)) $nfdump->setOption('-6', $output['IPv6']);
-        if (!empty($aggregate_command)) $nfdump->setOption('-a', $aggregate_command);
-        $nfdump->setFilter($filter);
+        if (!empty($sort)) $processor->setOption('-O', 'tstart');
+        if (array_key_exists('IPv6', $output)) $processor->setOption('-6', $output['IPv6']);
+        if (!empty($aggregate_command)) $processor->setOption('-a', $aggregate_command);
+        $processor->setFilter($filter);
         
         try {
-            $return = $nfdump->execute();
+            $return = $processor->execute();
         } catch (\Exception $e) {
             $this->error(503, $e->getMessage());
         }

--- a/backend/common/config.php
+++ b/backend/common/config.php
@@ -10,6 +10,10 @@ abstract class Config {
      * @var \nfsen_ng\datasources\Datasource
      */
     static $db;
+    /**
+      * @var \nfsen_ng\processor\Processor
+      */
+    static $processorClass;
     private static $initialized = false;
     
     private function __construct() {
@@ -32,6 +36,16 @@ abstract class Config {
         } else {
             throw new \Exception('Failed loading class ' . self::$cfg['general']['db'] . '. The class doesn\'t exist.');
         }
+
+        // find processor
+        $proc_class = array_key_exists('processor', self::$cfg['general']) ? self::$cfg['general']['processor'] : 'NfDump';
+        self::$processorClass = 'nfsen_ng\\processor\\' . $proc_class;
+        if (!class_exists(self::$processorClass))
+            throw new \Exception('Failed loading class ' . self::$processorClass . '. The class doesn\'t exist.');
+
+        $proc_iface = 'nfsen_ng\\processor\\Processor';
+        if (!in_array($proc_iface, class_implements(self::$processorClass)))
+            throw new \Exception('Processor class ' . self::$processorClass . ' doesn\'t implement ' . $proc_iface . '.');
     }
     
 }

--- a/backend/processor/nfdump.php
+++ b/backend/processor/nfdump.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace nfsen_ng\common;
+namespace nfsen_ng\processor;
 
-class NfDump {
+use nfsen_ng\common\{Debug, Config};
+
+class NfDump implements Processor {
     private $cfg = array(
         'env' => array(),
         'option' => array(),

--- a/backend/processor/processor.php
+++ b/backend/processor/processor.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace nfsen_ng\processor;
+
+/**
+ * Provides access to netflow data using a model
+ * compatible with nfdump commandline options
+ */
+interface Processor {
+
+    /**
+     * Sets an option's value
+     *
+     * @param $option
+     * @param $value
+     */
+    public function setOption($option, $value);
+
+    /**
+     * Sets a filter's value
+     *
+     * @param $filter
+     */
+    public function setFilter($filter);
+
+    /**
+     * Executes the processor command, tries to throw an
+     * exception based on the return code
+     * @return array
+     * @throws \Exception
+     */
+    public function execute();
+
+}

--- a/backend/settings/settings.php.dist
+++ b/backend/settings/settings.php.dist
@@ -16,6 +16,7 @@ $nfsen_config = array(
             'source1', 'source2',
         ),
         'db' => 'RRD',
+        'processor' => 'NfDump',
     ),
     'frontend' => array(
         'reload_interval' => 60,


### PR DESCRIPTION
This diff introduces a Processor interface in the processor sub-directory and moves nfdump.php into that directory implementing the Processor interface. This supports custom Processor implementations by specifying a processor class in settings (similarly to the way custom databases are supported). NfDump becomes the default processor if no processor is specified.

I use this to allow nfsen-ng to run in a php chroot without direct access to the nfcapd files. The original nfsen supports this. My custom nfdump model (not included here), which is similar to the original nfsen, is to run a separate nfsend daemon and have nfsen-ng communicate via a fifo. This could also work using a socket which would allow nfsen-ng to run on a different host from that where the nfcapd files reside.