### PR TITLE
Support output format for record stats

### DIFF
--- a/backend/api/api.php
+++ b/backend/api/api.php
@@ -49,7 +49,11 @@ class API {
         $args = array();
         // iterate over each parameter
         foreach ($method->getParameters() as $arg) {
-            if (!isset($_REQUEST[$arg->name])) $this->error(400, 'Expected parameter ' . $arg->name);
+            if (!isset($_REQUEST[$arg->name])) {
+                if ($arg->isOptional())
+                    continue;
+                $this->error(400, 'Expected parameter ' . $arg->name);
+            }
             
             // make sure the data types are correct
             switch ($arg->getType()) {
@@ -158,7 +162,7 @@ class API {
         int $top,
         string $for,
         string $limit,
-        array $output
+        array $output = array()
     ) {
         $sources = implode(':', $sources);
         
@@ -166,6 +170,8 @@ class API {
         $processor->setOption('-M', $sources); // multiple sources
         $processor->setOption('-R', array($datestart, $dateend)); // date range
         $processor->setOption('-n', $top);
+        if (array_key_exists('format', $output))
+            $processor->setOption('-o', $output['format']);
         $processor->setOption('-s', $for);
         if (!empty($limit)) $processor->setOption('-l', $limit); // todo -L for traffic, -l for packets
         if (isset($output['IPv6'])) $processor->setOption('-6', null);

--- a/backend/processor/nfdump.php
+++ b/backend/processor/nfdump.php
@@ -8,7 +8,7 @@ class NfDump implements Processor {
     private $cfg = array(
         'env' => array(),
         'option' => array(),
-        'format' => 'line',
+        'format' => null,
         'filter' => array()
     );
     private $clean = array();
@@ -45,11 +45,6 @@ class NfDump implements Processor {
                 break;
             case '-o':
                 $this->cfg['format'] = $value;
-                break;
-            case '-s':
-            case '-S':
-                $this->cfg['option'][$option] = $value;
-                $this->cfg['format'] = (strstr($value, 'record') === false) ? 'stats' : 'stats_flows';
                 break;
             default:
                 $this->cfg['option'][$option] = $value;
@@ -119,7 +114,9 @@ class NfDump implements Processor {
         // slice csv (only return the fields actually wanted)
         $fields_active = array();
         $parsed_header = false;
-        $format = ($this->cfg['format'] !== 'stats') ? $this->get_output_format($this->cfg['format']) : false;
+        $format = false;
+        if (isset($this->cfg['format']))
+            $format = $this->get_output_format($this->cfg['format']);
         
         foreach ($output as $i => &$line) {
             

--- a/frontend/js/nfsen-ng.js
+++ b/frontend/js/nfsen-ng.js
@@ -726,9 +726,11 @@ $(document).ready(function() {
             s_for = $('#statsFilterForSelection').val(),
             title = $('#statsFilterForSelection :selected').text(),
             sort = $('#statsFilterOrderBySelection').val(),
-            output = {
-                format: $('#filterOutputSelection').val(),
-            };
+            fmt = $('#filterOutputSelection'),
+            output = {};
+
+        if (!fmt.prop('disabled'))
+            output.format = fmt.val();
 
         // parse form values to generate a proper API request
         var aggregate = parse_aggregation_fields();


### PR DESCRIPTION
As it stands, the frontend enables the output format dropdown for record stats but the backend ignores the specified format. While addressing this I also chose to make the output format an optional parameter so that the frontend does not supply any output format when the output format dropdown is disabled (for non-record stats). That way the behaviour is clear - if the frontend supplies an output format the backend honours it.

There are still problems with the way the custom output format works, which will be addressed in future diffs.