### PR TITLE
Use dygraph stepPlot

### DIFF
--- a/frontend/js/nfsen-ng.js
+++ b/frontend/js/nfsen-ng.js
@@ -585,6 +585,7 @@ $(document).ready(function() {
                         labelsDiv: $('#legend')[0],
                         labelsSeparateLines: true,
                         legend: 'always',
+                        stepPlot: true,
                         showRangeSelector: true,
                         dateWindow: [dygraph_data[0][0], dygraph_data[dygraph_data.length - 1][0]],
                         zoomCallback: dygraph_zoom,


### PR DESCRIPTION
I noticed the following comment in issue #31:

>  However I don't really like the "ramp up, ramp down / join-the-dots" line; I think that nfsen is more accurate by showing it as a bar,

I prefer the bar graph as well, which I think can be achieved using dygraph stepPlot. Maybe you prefer this to be user selectable in the UI.