### PR TITLE
Disable filter controls that offer no options

### DIFF
--- a/frontend/js/nfsen-ng.js
+++ b/frontend/js/nfsen-ng.js
@@ -346,6 +346,17 @@ $(document).ready(function() {
         updateDropdown('sources', config['sources']);
         updateDropdown('ports', config['ports']);
 
+        if (config['sources'].length == 1) {
+            $('#filterDisplaySelect option[value="sources"]').remove();
+            $('#filterSources').hide();
+        }
+
+        if (config['ports'].length == 0)
+            $('#filterDisplaySelect option[value="ports"]').remove();
+
+        if ($('#filterDisplaySelect').length == 1)
+            $('#filterDisplay').hide();
+
         init_rangeslider();
 
         // show graph for one year by default


### PR DESCRIPTION
This diff hides the source, port, filter controls that do not offer any useful value, such as the sources drop-down when there is only one source.