### PR TITLE
When launching as service, TERM is not set

### DIFF
--- a/backend/vendor/progressbar.php
+++ b/backend/vendor/progressbar.php
@@ -331,7 +331,7 @@ class progressbar
     protected static function setWidth($width = null)
     {
         if ($width === null) {
-            if (DIRECTORY_SEPARATOR === '/') {
+            if (DIRECTORY_SEPARATOR === '/' && getenv("TERM")) {
                 $width = `tput cols`;
             }
             if ($width < 80) {


### PR DESCRIPTION
When the service is started, the TERM is not set, so tput can not determine the width of the screen.
It generate an error log "tput: No value for $TERM and no -T specified"