### PR TITLE
 Update to support persistent config/localStorage filters

### DIFF
--- a/backend/api/Api.php
+++ b/backend/api/Api.php
@@ -276,7 +276,7 @@ class Api {
         $frontend = Config::$cfg['frontend'];
 
         $stored_output_formats = []; // todo implement
-        $stored_filters = []; // todo implement
+        $stored_filters =  Config::$cfg['general']['filters'];
 
         $folder = \dirname(__FILE__, 2);
         $pidfile = $folder . '/nfsen-ng.pid';

--- a/backend/settings/settings.php.dist
+++ b/backend/settings/settings.php.dist
@@ -15,6 +15,11 @@ $nfsen_config = [
         'sources' => [
             'source1', 'source2',
         ],
+        'filters' => [
+            'Filters',
+            'proto udp',
+            'proto tcp',
+        ],
         'db' => 'RRD',
         'processor' => 'NfDump',
     ],

--- a/frontend/css/nfsen-ng.css
+++ b/frontend/css/nfsen-ng.css
@@ -1,4 +1,8 @@
 /* general */
+@media (prefers-color-scheme: light) { html { filter: invert(0.0);  } :root { } }
+@media (prefers-color-scheme: dark)  { html { filter: invert(0.85); } :root { } }
+html { filter: none; }
+
 :root {
     --bs-primary: #ccc;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,6 +49,10 @@
                     </svg>
                     </a>
                 </li>
+                <li role="presentation" class="nav-item">
+                    <a class="nav-link" data-view="config" href="#">Config ⚙️
+                    </a>
+                </li>
             </ul>
         </header>
         <div id="filterContainer" class="container-fluid tab-content">
@@ -91,6 +95,28 @@
                         </div>
                     </div>
 
+                    <div class="d-none col-xs-6 col-sm-2" data-view="config">
+                    <ul>
+                    <li>
+                    Config <a href="../api/config">/api/config</a>
+                    </li>
+                    <li>
+                        Theme
+                        <a href="javascript:window.localStorage.setItem('theme', 'light')">Light</a>
+                        <a href="javascript:window.localStorage.setItem('theme', 'dark')">Dark</a>
+                    </li>
+
+                    <script>
+                    var theme = window.localStorage.getItem("theme");
+                    var styleId = document.styleSheets.length - 1;
+                    var ruleId = 2;
+                    switch (theme)
+                    {
+                        case "light": document.styleSheets[styleId].rules[ruleId].style.filter="invert(0.0)"; break;;
+                        case "dark": document.styleSheets[styleId].rules[ruleId].style.filter="invert(0.9)"; break;;
+                    }
+                    </script>
+                    </div>
 
                     <div id="filterDisplay" class="d-none col-xs-6 col-sm-2" data-view="graphs">
                         <p class="h6">Display</p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -219,32 +219,24 @@
                     </div>
 
 
-                    <div id="filterNfdump" class="d-none col-xs-12 col-sm-7 col-md-5" data-view="flows statistics">
+                    <div id="filterNfdump" class="d-none col-xs-12 col-sm-7 col-md-5" data-view="graphs flows statistics">
 
                         <p class="h6">NFDUMP filter <span aria-hidden="true" data-bs-toggle="tooltip" data-bs-placement="right" title="The filter syntax is similar to the well known pcap library used by tcpdump. All keywords are case-independent. Example: dst port 80"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle-fill" viewBox="0 0 16 16">
                             <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2"/>
                         </svg></span></p>
 
                         <div class="form-group">
-                            <textarea class="form-control" id="filterNfdumpTextarea" rows="3"></textarea>
+                            <textarea class="form-control" id="filterNfdumpTextarea" rows="3" autocomplete="on"></textarea>
                         </div>
 
                         <div class="btn-group">
-                            <div class="btn-group">
-
-                                <button type="button" class="btn btn-outline-primary dropdown-toggle disabled" data-bs-toggle="dropdown">
-                                    Filters
-                                    <span class="caret"></span>
-                                </button>
-                                <ul class="dropdown-menu disabled">
-                                    <li><a>Dynamically load</a></li>
-                                    <li><a>Filters</a></li>
-                                    <li><a>From Backend</a></li>
-                                </ul>
+                            <div id="filterFilters" class="form-group">
+                            <select id="filterFiltersSelect" class="form-control form-select"  style="width:6em">
+                            </select>
                             </div>
 
-                            <button type="button" class="btn btn-outline-primary disabled">Delete filter (server)</button>
-                            <button type="button" class="btn btn-outline-primary disabled">Save filter (server)</button>
+                            <button id="filterFiltersButtonRemove" type="button" class="btn btn-outline-primary" >Delete filter (server)</button>
+                            <button id="filterFiltersButtonSave" type="button" class="btn btn-outline-primary" >Save filter (server)</button>
                         </div>
 
                     </div>


### PR DESCRIPTION
This attempts to address #4 to provide two types of filters: 1) filters defined in settings.php, and, also provide 2) localStorage filters.

Works as far as I've been using it, but probably could be reworked to be cleaner/prettier.