### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:8.3-apache 
+
+ENV TZ="Europe/Moscow"
+WORKDIR /var/www/html
+
+COPY . /var/www/html/
+
+RUN apt-get update && apt-get -y install rrdtool librrd-dev && \
+    pecl install rrd && \
+    docker-php-ext-enable rrd && \
+    a2enmod rewrite deflate headers expires && \
+    curl -o composer.phar https://getcomposer.org/download/2.8.3/composer.phar && \
+    php composer.phar install --no-dev
+
+RUN sed -ri -e 's!AllowOverride None!AllowOverride All!' /etc/apache2/apache2.conf
+
+CMD ["sh", "-c", "php ./backend/cli.php start && apache2-foreground"]


### PR DESCRIPTION
It's simple Dockerfile to run nfsen-ng in container.
All you need is mount volumes with nfdump binary and data, like this:
```
docker build -t nfsen-ng .
docker run -v /var/cache/nfdump/:/var/cache/nfdump/ \
-v /usr/bin/nfdump:/usr/bin/nfdump \
-p 80:80 nfsen-ng:latest
```
