### PR TITLE
Update Dockerization and NFSen-NG setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+FROM php:8.3-apache
+
+ENV TZ="Europe/Moscow"
+WORKDIR /var/www/html
+
+# Install system dependencies
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    software-properties-common \
+    git \
+    pkg-config \
+    apache2 \
+    libapache2-mod-php8.3 \
+    php8.3 \
+    php8.3-dev \
+    php8.3-mbstring \
+    rrdtool \
+    librrd-dev \
+    flex \
+    libbz2-dev \
+    yacc \
+    unzip \
+    wget \
+    curl \
+    && add-apt-repository -y ppa:ondrej/php \
+    && apt-get update
+
+# Compile and install latest nfdump
+RUN wget https://github.com/phaag/nfdump/archive/refs/tags/v1.7.6.zip \
+    && unzip v1.7.6.zip \
+    && cd nfdump-1.7.6 \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr/local/nfdump \
+    && make \
+    && make install \
+    && ldconfig \
+    && nfdump -V
+
+# Enable Apache modules
+RUN a2enmod rewrite deflate headers expires
+
+# Install PHP rrd extension
+RUN pecl install rrd \
+    && echo "extension=rrd.so" > /etc/php/8.3/mods-available/rrd.ini \
+    && phpenmod rrd mbstring
+
+# Configure Apache to allow .htaccess overrides
+RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+
+# Setup volumes for persistent data
+VOLUME ["/data/nfsen", "/config/nfsen"]
+
+# Install NFSen-NG
+RUN git clone https://github.com/mbolli/nfsen-ng.git /var/www/html/nfsen-ng \
+    && chmod +x /var/www/html/nfsen-ng/backend/cli.php
+
+# Install composer and PHP dependencies
+RUN curl -sS https://getcomposer.org/download/latest-stable/composer.phar -o /usr/local/bin/composer \
+    && chmod +x /usr/local/bin/composer \
+    && cd /var/www/html/nfsen-ng \
+    && composer install --no-dev
+
+# Auto-config script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  nfsen:
+    build: .
+    container_name: nfsen
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nfsen-data:/data/nfsen
+      - ./nfsen-config:/config/nfsen
+    restart: unless-stopped

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Check if config exists, if not copy default
+if [ ! -f /config/nfsen/settings.php ]; then
+    echo "No settings.php found in /config/nfsen. Copying default..."
+    cp /var/www/html/nfsen-ng/backend/settings/settings.php.dist /config/nfsen/settings.php
+fi
+
+# Link settings.php from config volume to nfsen-ng directory
+ln -sf /config/nfsen/settings.php /var/www/html/nfsen-ng/backend/settings/settings.php
+
+# Ensure permissions
+chown -R www-data:www-data /var/www/html
+chown -R www-data:www-data /data/nfsen
+chown -R www-data:www-data /config/nfsen
+
+# Execute main container command
+exec "$@"


### PR DESCRIPTION
This PR introduces a complete Dockerization setup for NFSen-NG, including:

- PHP 8.3 + Apache environment
- Installation of required PHP extensions (rrd, mbstring)
- Compilation and installation of the latest nfdump (v1.7.6)
- Automatic configuration setup for NFSen-NG with persistent volumes
- Apache modules enabled (rewrite, deflate, headers, expires)
- Composer dependencies installed for backend
- docker-entrypoint script to auto-copy and link settings.php if not present
- docker-compose setup for easier container management and persistent data/configs

These changes allow for a fully self-contained, containerized environment ready to run NFSen-NG without manual configuration steps.