### PR TITLE
Dockerize NFSen-NG with PHP 8.3, Apache, nfdump 1.7.6, and RRD support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Base image: PHP 8.3 + Apache
+FROM php:8.3-apache
+
+ENV TZ="Europe/Moscow"
+WORKDIR /var/www/html
+
+# Install dependencies required for nfdump and NFSen-NG
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git pkg-config rrdtool librrd-dev \
+    flex bison libbz2-dev zlib1g-dev \
+    build-essential autoconf automake libtool \
+    unzip wget curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add nfdump to PATH
+ENV PATH="/usr/local/nfdump/bin:${PATH}"
+
+# Compile and install nfdump 1.7.6
+RUN wget https://github.com/phaag/nfdump/archive/refs/tags/v1.7.6.zip \
+    && unzip v1.7.6.zip \
+    && cd nfdump-1.7.6 \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr/local/nfdump \
+    && make \
+    && make install \
+    && ldconfig \
+    && nfdump -V
+
+# Enable Apache modules
+RUN a2enmod rewrite deflate headers expires
+
+# Install PHP RRD extension (mbstring already included in base image)
+RUN pecl install rrd \
+    && echo "extension=rrd.so" > /usr/local/etc/php/conf.d/rrd.ini
+
+# Setup volumes for persistent data and configuration
+VOLUME ["/data/nfsen", "/config/nfsen"]
+
+# Install NFSen-NG
+RUN git clone https://github.com/mbolli/nfsen-ng.git /var/www/html/nfsen-ng \
+    && chmod +x /var/www/html/nfsen-ng/backend/cli.php
+
+# Install composer and backend dependencies
+RUN curl -sS https://getcomposer.org/download/latest-stable/composer.phar -o /usr/local/bin/composer \
+    && chmod +x /usr/local/bin/composer \
+    && cd /var/www/html/nfsen-ng \
+    && composer install --no-dev
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN pecl install rrd \
     && echo "extension=rrd.so" > /usr/local/etc/php/conf.d/rrd.ini
 
 # Setup volumes for persistent data and configuration
-VOLUME ["/data/nfsen", "/config/nfsen"]
+VOLUME ["/data/nfsen-ng", "/config/nfsen-ng"]
 
 # Install NFSen-NG
 RUN git clone https://github.com/mbolli/nfsen-ng.git /var/www/html/nfsen-ng \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Base image: PHP 8.3 + Apache
 FROM php:8.3-apache
 
-ENV TZ="Europe/Moscow"
+ENV TZ="UTC"
 WORKDIR /var/www/html
 
 # Install dependencies required for nfdump and NFSen-NG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: "3.9"
 services:
   nfsen:
     build: .
-    container_name: nfsen
+    container_name: nfsen-ng
     ports:
       - "8080:80"
     volumes:
-      - ./nfsen-data:/data/nfsen
-      - ./nfsen-config:/config/nfsen
+      - ./nfsen-ng-data:/data/nfsen-ng
+      - ./nfsen-ng-config:/config/nfsen-ng
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  nfsen:
+    build: .
+    container_name: nfsen
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nfsen-data:/data/nfsen
+      - ./nfsen-config:/config/nfsen
+    restart: unless-stopped

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,18 +2,18 @@
 set -e
 
 # If settings.php does not exist in config volume, copy default
-if [ ! -f /config/nfsen/settings.php ]; then
-    echo "No settings.php found in /config/nfsen. Copying default..."
-    cp /var/www/html/nfsen-ng/backend/settings/settings.php.dist /config/nfsen/settings.php
+if [ ! -f /config/nfsen-ng/settings.php ]; then
+    echo "No settings.php found in /config/nfsen-ng. Copying default..."
+    cp /var/www/html/nfsen-ng/backend/settings/settings.php.dist /config/nfsen-ng/settings.php
 fi
 
-# Link settings.php to NFSen-NG directory
-ln -sf /config/nfsen/settings.php /var/www/html/nfsen-ng/backend/settings/settings.php
+# Link settings.php to nfsen-ng directory
+ln -sf /config/nfsen-ng/settings.php /var/www/html/nfsen-ng/backend/settings/settings.php
 
 # Ensure correct ownership
 chown -R www-data:www-data /var/www/html
-chown -R www-data:www-data /data/nfsen
-chown -R www-data:www-data /config/nfsen
+chown -R www-data:www-data /data/nfsen-ng
+chown -R www-data:www-data /config/nfsen-ng
 
 # Execute container command
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# If settings.php does not exist in config volume, copy default
+if [ ! -f /config/nfsen/settings.php ]; then
+    echo "No settings.php found in /config/nfsen. Copying default..."
+    cp /var/www/html/nfsen-ng/backend/settings/settings.php.dist /config/nfsen/settings.php
+fi
+
+# Link settings.php to NFSen-NG directory
+ln -sf /config/nfsen/settings.php /var/www/html/nfsen-ng/backend/settings/settings.php
+
+# Ensure correct ownership
+chown -R www-data:www-data /var/www/html
+chown -R www-data:www-data /data/nfsen
+chown -R www-data:www-data /config/nfsen
+
+# Execute container command
+exec "$@"


### PR DESCRIPTION
This pull request dockerizes the NFSen-NG project, providing a fully containerized setup with:

- PHP 8.3 and Apache preconfigured
- nfdump 1.7.6 compiled and installed
- PHP RRD extension installed and ready
- mbstring included (enabled by default in PHP 8.3)
- Composer dependencies installed for NFSen-NG
- Apache modules (rewrite, deflate, headers, expires) enabled
- Volumes for persistent data (/data/nfsen) and configuration (/config/nfsen)
- Automatic creation of backend settings.php if missing

The Dockerfile ensures a reproducible environment for NFSen-NG, simplifying deployment and development. 
All steps from dependency installation, compilation of nfdump, PHP extension setup, and NFSen-NG configuration are automated.

This update does not change any of the core functionality of NFSen-NG, only provides a containerized environment for easier setup.